### PR TITLE
fix: pass filename in `from` option in PostCSS config

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.0.0-development",
   "description": "Transform PostCSS in Rollup using options from a config file.",
   "main": "src/index.js",
+  "engines": {
+    "node": ">=8.6.0"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Updater/rollup-plugin-postcss-config.git"

--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,7 @@ module.exports = function (options = {}) {
 
       return config
         .then(({ plugins, options }) =>
-          postcss(plugins).process(code, options),
+          postcss(plugins).process(code, { from: id, ...options }),
           console.error,
         )
         .then(({ css: code, map }) =>


### PR DESCRIPTION
This fixes `browserslist` integration with `autoprefixer`.

BREAKING CHANGE: Using Object spread syntax. Not sure what versionof Node was technically supported before, but now it's explicitly 8.6.0 and above.